### PR TITLE
added new field rangeUnit in StateDescription

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
@@ -273,6 +273,7 @@ public abstract class AbstractStorageBasedTypeProvider
         entity.step = fragment.getStep();
         entity.options = fragment.getOptions();
         entity.pattern = fragment.getPattern();
+        entity.rangeUnit = fragment.getRangeUnit();
         entity.isReadOnly = fragment.isReadOnly();
         return entity;
     }
@@ -377,6 +378,9 @@ public abstract class AbstractStorageBasedTypeProvider
         if (entity.pattern != null) {
             builder.withPattern(Objects.requireNonNull(entity.pattern));
         }
+        if (entity.rangeUnit != null) {
+            builder.withPattern(Objects.requireNonNull(entity.rangeUnit));
+        }
         builder.withReadOnly(entity.isReadOnly);
         return builder.build();
     }
@@ -446,6 +450,7 @@ public abstract class AbstractStorageBasedTypeProvider
         public @Nullable BigDecimal step;
         public @Nullable List<StateOption> options;
         public @Nullable String pattern;
+        public @Nullable String rangeUnit;
         public boolean isReadOnly = false;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
@@ -128,6 +128,11 @@ public class StateDescriptionConverter extends GenericUnmarshaller<StateDescript
             builder.withPattern(pattern);
         }
 
+        String rangeUnit = attributes.get("rangeUnit");
+        if (rangeUnit != null) {
+            builder.withRangeUnit(rangeUnit);
+        }
+
         NodeList nodes = (NodeList) context.convertAnother(context, NodeList.class);
         NodeIterator nodeIterator = new NodeIterator(nodes.getList());
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
@@ -34,7 +34,8 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
     private static class StateDescriptionImpl extends StateDescription {
         StateDescriptionImpl(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
-                @Nullable String pattern, @Nullable String rangeUnit, boolean readOnly, @Nullable List<StateOption> options) {
+                @Nullable String pattern, @Nullable String rangeUnit, boolean readOnly,
+                @Nullable List<StateOption> options) {
             super(minimum, maximum, step, pattern, rangeUnit, readOnly, options);
         }
     }
@@ -179,12 +180,13 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
     @Override
     public @Nullable StateDescription toStateDescription() {
-        if (minimum == null && maximum == null && step == null && readOnly == null && pattern == null && rangeUnit == null
-                && options == null) {
+        if (minimum == null && maximum == null && step == null && readOnly == null && pattern == null
+                && rangeUnit == null && options == null) {
             return null;
         }
         final Boolean ro = readOnly;
-        return new StateDescriptionImpl(minimum, maximum, step, pattern, rangeUnit, ro != null && ro.booleanValue(), options);
+        return new StateDescriptionImpl(minimum, maximum, step, pattern, rangeUnit, ro != null && ro.booleanValue(),
+                options);
     }
 
     /**
@@ -247,13 +249,14 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         StateDescriptionFragmentImpl other = (StateDescriptionFragmentImpl) obj;
         return Objects.equals(minimum, other.minimum) && Objects.equals(maximum, other.maximum)
                 && Objects.equals(step, other.step) && Objects.equals(pattern, other.pattern)
-                && Objects.equals(rangeUnit, other.rangeUnit)
-                && Objects.equals(readOnly, other.readOnly) && Objects.equals(options, other.options);
+                && Objects.equals(rangeUnit, other.rangeUnit) && Objects.equals(readOnly, other.readOnly)
+                && Objects.equals(options, other.options);
     }
 
     @Override
     public String toString() {
         return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
-                + pattern + ", rangeUnit=" + rangeUnit + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
+                + pattern + ", rangeUnit=" + rangeUnit + ", readOnly=" + readOnly + ", channelStateOptions=" + options
+                + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
@@ -34,8 +34,8 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
     private static class StateDescriptionImpl extends StateDescription {
         StateDescriptionImpl(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
-                @Nullable String pattern, boolean readOnly, @Nullable List<StateOption> options) {
-            super(minimum, maximum, step, pattern, readOnly, options);
+                @Nullable String pattern, @Nullable String rangeUnit, boolean readOnly, @Nullable List<StateOption> options) {
+            super(minimum, maximum, step, pattern, rangeUnit, readOnly, options);
         }
     }
 
@@ -43,6 +43,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
     private @Nullable BigDecimal maximum;
     private @Nullable BigDecimal step;
     private @Nullable String pattern;
+    private @Nullable String rangeUnit;
     private @Nullable Boolean readOnly;
     private @Nullable List<StateOption> options;
 
@@ -60,18 +61,20 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
      * @param maximum maximum value of the state
      * @param step step size
      * @param pattern pattern to render the state
+     * @param rangeUnit unit of the range
      * @param readOnly if the state can be changed by the system
      * @param options predefined list of options
      * @deprecated use {@link StateDescriptionFragmentBuilder} instead.
      */
     @Deprecated
     public StateDescriptionFragmentImpl(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum,
-            @Nullable BigDecimal step, @Nullable String pattern, @Nullable Boolean readOnly,
+            @Nullable BigDecimal step, @Nullable String pattern, @Nullable String rangeUnit, @Nullable Boolean readOnly,
             @Nullable List<StateOption> options) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.step = step;
         this.pattern = pattern;
+        this.rangeUnit = rangeUnit;
         this.readOnly = readOnly;
         this.options = options == null || options.isEmpty() ? List.of() : Collections.unmodifiableList(options);
     }
@@ -89,6 +92,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         this.maximum = legacy.getMaximum();
         this.step = legacy.getStep();
         this.pattern = legacy.getPattern();
+        this.rangeUnit = legacy.getRangeUnit();
         this.readOnly = Boolean.valueOf(legacy.isReadOnly());
         if (!legacy.getOptions().isEmpty()) {
             this.options = legacy.getOptions();
@@ -105,6 +109,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         this.maximum = source.getMaximum();
         this.step = source.getStep();
         this.pattern = source.getPattern();
+        this.rangeUnit = source.getRangeUnit();
         this.readOnly = source.isReadOnly();
         this.options = source.getOptions();
     }
@@ -146,6 +151,15 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
     }
 
     @Override
+    public @Nullable String getRangeUnit() {
+        return rangeUnit;
+    }
+
+    public void setRangeUnit(String rangeUnit) {
+        this.rangeUnit = rangeUnit;
+    }
+
+    @Override
     public @Nullable Boolean isReadOnly() {
         return readOnly;
     }
@@ -165,12 +179,12 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
     @Override
     public @Nullable StateDescription toStateDescription() {
-        if (minimum == null && maximum == null && step == null && readOnly == null && pattern == null
+        if (minimum == null && maximum == null && step == null && readOnly == null && pattern == null && rangeUnit == null
                 && options == null) {
             return null;
         }
         final Boolean ro = readOnly;
-        return new StateDescriptionImpl(minimum, maximum, step, pattern, ro != null && ro.booleanValue(), options);
+        return new StateDescriptionImpl(minimum, maximum, step, pattern, rangeUnit, ro != null && ro.booleanValue(), options);
     }
 
     /**
@@ -193,6 +207,9 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         if (pattern == null) {
             pattern = fragment.getPattern();
         }
+        if (rangeUnit == null) {
+            rangeUnit = fragment.getRangeUnit();
+        }
         if (readOnly == null) {
             readOnly = fragment.isReadOnly();
         }
@@ -210,6 +227,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         result = prime * result + (maximum != null ? maximum.hashCode() : 0);
         result = prime * result + (step != null ? step.hashCode() : 0);
         result = prime * result + (pattern != null ? pattern.hashCode() : 0);
+        result = prime * result + (rangeUnit != null ? rangeUnit.hashCode() : 0);
         result = prime * result + (readOnly ? 1231 : 1237);
         result = prime * result + (options != null ? options.hashCode() : 0);
         return result;
@@ -229,12 +247,13 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         StateDescriptionFragmentImpl other = (StateDescriptionFragmentImpl) obj;
         return Objects.equals(minimum, other.minimum) && Objects.equals(maximum, other.maximum)
                 && Objects.equals(step, other.step) && Objects.equals(pattern, other.pattern)
+                && Objects.equals(rangeUnit, other.rangeUnit)
                 && Objects.equals(readOnly, other.readOnly) && Objects.equals(options, other.options);
     }
 
     @Override
     public String toString() {
         return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
-                + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
+                + pattern + ", rangeUnit=" + rangeUnit + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
@@ -48,7 +48,8 @@ public class StateDescription {
      * @param options predefined list of options
      */
     protected StateDescription(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
-            @Nullable String pattern, @Nullable String rangeUnit, boolean readOnly, @Nullable List<StateOption> options) {
+            @Nullable String pattern, @Nullable String rangeUnit, boolean readOnly,
+            @Nullable List<StateOption> options) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.step = step;
@@ -132,7 +133,7 @@ public class StateDescription {
         result = prime * result + (maximum != null ? maximum.hashCode() : 0);
         result = prime * result + (step != null ? step.hashCode() : 0);
         result = prime * result + (pattern != null ? pattern.hashCode() : 0);
-        result - prime * result + (rangeUnit != null ? rangeUnit.hashCode() : 0);
+        result = prime * result + (rangeUnit != null ? rangeUnit.hashCode() : 0);
         result = prime * result + (readOnly ? 1231 : 1237);
         result = prime * result + options.hashCode();
         return result;
@@ -152,14 +153,14 @@ public class StateDescription {
         StateDescription other = (StateDescription) obj;
         return Objects.equals(minimum, other.minimum) && Objects.equals(maximum, other.maximum)
                 && Objects.equals(step, other.step) && Objects.equals(pattern, other.pattern)
-                && Objects.equals(rangeUnit, other.rangeUnit)
-                && readOnly == other.readOnly //
+                && Objects.equals(rangeUnit, other.rangeUnit) && readOnly == other.readOnly //
                 && options.equals(other.options);
     }
 
     @Override
     public String toString() {
         return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
-                + pattern + ", rangeUnit=" + rangeUnit + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
+                + pattern + ", rangeUnit=" + rangeUnit + ", readOnly=" + readOnly + ", channelStateOptions=" + options
+                + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
@@ -32,6 +32,7 @@ public class StateDescription {
     protected @Nullable final BigDecimal maximum;
     protected @Nullable final BigDecimal step;
     protected @Nullable final String pattern;
+    protected @Nullable final String rangeUnit;
     protected final boolean readOnly;
     protected final List<StateOption> options;
 
@@ -42,15 +43,17 @@ public class StateDescription {
      * @param maximum maximum value of the state
      * @param step step size
      * @param pattern pattern to render the state
+     * @param rangeUnit unit of the range
      * @param readOnly if the state can be changed by the system
      * @param options predefined list of options
      */
     protected StateDescription(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
-            @Nullable String pattern, boolean readOnly, @Nullable List<StateOption> options) {
+            @Nullable String pattern, @Nullable String rangeUnit, boolean readOnly, @Nullable List<StateOption> options) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.step = step;
         this.pattern = pattern;
+        this.rangeUnit = rangeUnit;
         this.readOnly = readOnly;
         this.options = options == null ? List.of() : Collections.unmodifiableList(options);
     }
@@ -92,6 +95,15 @@ public class StateDescription {
     }
 
     /**
+     * Returns the unit of range
+     * 
+     * @return rangeUnit
+     */
+    public @Nullable String getRangeUnit() {
+        return rangeUnit;
+    }
+
+    /**
      *
      * Returns {@code true} if the state can only be read but not written or {@code false} if the state can also be
      * written.
@@ -120,6 +132,7 @@ public class StateDescription {
         result = prime * result + (maximum != null ? maximum.hashCode() : 0);
         result = prime * result + (step != null ? step.hashCode() : 0);
         result = prime * result + (pattern != null ? pattern.hashCode() : 0);
+        result - prime * result + (rangeUnit != null ? rangeUnit.hashCode() : 0);
         result = prime * result + (readOnly ? 1231 : 1237);
         result = prime * result + options.hashCode();
         return result;
@@ -139,6 +152,7 @@ public class StateDescription {
         StateDescription other = (StateDescription) obj;
         return Objects.equals(minimum, other.minimum) && Objects.equals(maximum, other.maximum)
                 && Objects.equals(step, other.step) && Objects.equals(pattern, other.pattern)
+                && Objects.equals(rangeUnit, other.rangeUnit)
                 && readOnly == other.readOnly //
                 && options.equals(other.options);
     }
@@ -146,6 +160,6 @@ public class StateDescription {
     @Override
     public String toString() {
         return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
-                + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
+                + pattern + ", rangeUnit=" + rangeUnit + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragment.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragment.java
@@ -60,6 +60,14 @@ public interface StateDescriptionFragment {
     String getPattern();
 
     /**
+     * Returns the unit of the states.
+     *
+     * @return rangeUnit
+     */
+    @Nullable
+    String getRangeUnit();
+
+    /**
      * Returns true, if the state can only be read but not written. Typically a
      * sensor can be read only.
      *

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
@@ -32,6 +32,7 @@ public class StateDescriptionFragmentBuilder {
     private @Nullable BigDecimal maximum;
     private @Nullable BigDecimal step;
     private @Nullable String pattern;
+    private @Nullable String rangeUnit;
     private @Nullable Boolean readOnly;
     private @Nullable List<StateOption> options;
 
@@ -44,6 +45,7 @@ public class StateDescriptionFragmentBuilder {
         this.maximum = fragment.getMaximum();
         this.step = fragment.getStep();
         this.pattern = fragment.getPattern();
+        this.rangeUnit = fragment.getRangeUnit();
         this.readOnly = fragment.isReadOnly();
         final List<StateOption> stateOptions = fragment.getOptions();
         if (stateOptions != null && !stateOptions.isEmpty()) {
@@ -56,6 +58,7 @@ public class StateDescriptionFragmentBuilder {
         this.maximum = legacy.getMaximum();
         this.step = legacy.getStep();
         this.pattern = legacy.getPattern();
+        this.rangeUnit = legacy.getRangeUnit();
         this.readOnly = Boolean.valueOf(legacy.isReadOnly());
         if (!legacy.getOptions().isEmpty()) {
             this.options = new ArrayList<>(legacy.getOptions());
@@ -100,7 +103,7 @@ public class StateDescriptionFragmentBuilder {
      */
     @SuppressWarnings("deprecation")
     public StateDescriptionFragment build() {
-        return new StateDescriptionFragmentImpl(minimum, maximum, step, pattern, readOnly, options);
+        return new StateDescriptionFragmentImpl(minimum, maximum, step, pattern, rangeUnit, readOnly, options);
     }
 
     /**
@@ -144,6 +147,17 @@ public class StateDescriptionFragmentBuilder {
      */
     public StateDescriptionFragmentBuilder withPattern(String pattern) {
         this.pattern = pattern;
+        return this;
+    }
+
+    /**
+     * Set the rangeUnit for the resulting {@link StateDescriptionFragment}.
+     *
+     * @param rangeUnit the rangeUnit for the resulting {@link StateDescriptionFragment}.
+     * @return this builder.
+     */
+    public StateDescriptionFragmentBuilder withRangeUnit(String rangeUnit) {
+        this.rangeUnit = rangeUnit;
         return this;
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
@@ -87,8 +87,8 @@ public class StateDescriptionFragmentBuilderTest {
 
     @Test
     public void builderWithStateDescription() {
-        StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "pattern", "rangeUnit", true,
-                List.of(new StateOption("value", "label")));
+        StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "pattern",
+                "rangeUnit", true, List.of(new StateOption("value", "label")));
         StateDescriptionFragmentBuilder builder = StateDescriptionFragmentBuilder.create(source);
         StateDescriptionFragment fragment = builder.build();
 
@@ -109,8 +109,8 @@ public class StateDescriptionFragmentBuilderTest {
                 .withStep(BigDecimal.ONE).withPattern("pattern").withRangeUnit("rangeUnit").withReadOnly(Boolean.FALSE)
                 .withOptions(List.of(new StateOption("value", "label"))).build();
         StateDescriptionFragment fragment2 = builder.withMinimum(BigDecimal.ONE).withMaximum(BigDecimal.ONE)
-                .withStep(BigDecimal.ZERO).withPattern("pattern_new").withRangeUnit("rangeUnit_new").withReadOnly(Boolean.TRUE).withOptions(List.of())
-                .build();
+                .withStep(BigDecimal.ZERO).withPattern("pattern_new").withRangeUnit("rangeUnit_new")
+                .withReadOnly(Boolean.TRUE).withOptions(List.of()).build();
 
         assertThat(fragment1.getMinimum(), is(not(fragment2.getMinimum())));
         assertThat(fragment1.getMaximum(), is(not(fragment2.getMaximum())));

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
@@ -58,6 +58,11 @@ public class StateDescriptionFragmentBuilderTest {
     }
 
     @Test
+    public void builderWithRangeUnit() {
+        assertThat(builder.withRangeUnit("rangeUnit").build().getRangeUnit(), is("rangeUnit"));
+    }
+
+    @Test
     public void builderWithReadOnly() {
         assertThat(builder.withReadOnly(Boolean.TRUE).build().isReadOnly(), is(Boolean.TRUE));
     }
@@ -82,7 +87,7 @@ public class StateDescriptionFragmentBuilderTest {
 
     @Test
     public void builderWithStateDescription() {
-        StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "pattern", true,
+        StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "pattern", "rangeUnit", true,
                 List.of(new StateOption("value", "label")));
         StateDescriptionFragmentBuilder builder = StateDescriptionFragmentBuilder.create(source);
         StateDescriptionFragment fragment = builder.build();
@@ -91,6 +96,7 @@ public class StateDescriptionFragmentBuilderTest {
         assertThat(fragment.getMaximum(), is(source.getMaximum()));
         assertThat(fragment.getStep(), is(source.getStep()));
         assertThat(fragment.getPattern(), is(source.getPattern()));
+        assertThat(fragment.getRangeUnit(), is(source.getRangeUnit()));
         assertThat(fragment.isReadOnly(), is(source.isReadOnly()));
         assertThat(fragment.getOptions(), is(source.getOptions()));
 
@@ -100,16 +106,17 @@ public class StateDescriptionFragmentBuilderTest {
     @Test
     public void subsequentBuildsCreateIndependentFragments() {
         StateDescriptionFragment fragment1 = builder.withMinimum(BigDecimal.ZERO).withMaximum(BigDecimal.TEN)
-                .withStep(BigDecimal.ONE).withPattern("pattern").withReadOnly(Boolean.FALSE)
+                .withStep(BigDecimal.ONE).withPattern("pattern").withRangeUnit("rangeUnit").withReadOnly(Boolean.FALSE)
                 .withOptions(List.of(new StateOption("value", "label"))).build();
         StateDescriptionFragment fragment2 = builder.withMinimum(BigDecimal.ONE).withMaximum(BigDecimal.ONE)
-                .withStep(BigDecimal.ZERO).withPattern("pattern_new").withReadOnly(Boolean.TRUE).withOptions(List.of())
+                .withStep(BigDecimal.ZERO).withPattern("pattern_new").withRangeUnit("rangeUnit_new").withReadOnly(Boolean.TRUE).withOptions(List.of())
                 .build();
 
         assertThat(fragment1.getMinimum(), is(not(fragment2.getMinimum())));
         assertThat(fragment1.getMaximum(), is(not(fragment2.getMaximum())));
         assertThat(fragment1.getStep(), is(not(fragment2.getStep())));
         assertThat(fragment1.getPattern(), is(not(fragment2.getPattern())));
+        assertThat(fragment1.getRangeUnit(), is(not(fragment2.getRangeUnit())));
         assertThat(fragment1.isReadOnly(), is(not(fragment2.isReadOnly())));
         assertThat(fragment1.getOptions(), is(not(fragment2.getOptions())));
     }


### PR DESCRIPTION
### Addressed Issue (1 mark):
Thermostat configurations had ambiguous `min`, `max`, and `step` values without a clear unit, causing issues when switching between units like Celsius and Fahrenheit. (Issue #4432)

### What You Have Reengineered (1.5 marks):
- **`StateDescription` Class**: Added a `rangeUnit` attribute to make unit handling explicit.
- **Tests and Supporting Classes**: Updated related test cases and builder classes to incorporate and validate the `rangeUnit`.
- **Implementation Files**: Adjusted `StateDescriptionFragment` and its builder classes to recognize and use `rangeUnit`.

### Impact of Changes (1 mark):
The updates make thermostat settings clearer and ensure they work correctly across different units. Existing setups stay the same if rangeUnit isn’t used, so nothing breaks.

### Reengineering Strategy or Approach Used (1.5 marks):
A step-by-step refactoring approach was used to add `rangeUnit` without breaking existing code. Tests were updated to confirm everything functions smoothly, keeping things backward-compatible and ready for future enhancements.